### PR TITLE
Add max-width to main in summary.css

### DIFF
--- a/css/summary.css
+++ b/css/summary.css
@@ -5,6 +5,7 @@ main {
     align-items: center;
     justify-content: space-evenly;
     height: calc(100vh - 100px);
+    max-width: 1688px;
     flex: 1;
     margin-left: 232px;
 }


### PR DESCRIPTION
Add max-width: 1688px to the main selector in css/summary.css to constrain the layout on very wide viewports and prevent content from stretching excessively. Maintains existing alignment and spacing while improving consistency on large screens.