### PR TITLE
78 prevent the search container from moving on the left on scroll y

### DIFF
--- a/css/board-mobile.css
+++ b/css/board-mobile.css
@@ -14,6 +14,7 @@
     padding-left: 0;
     height: calc(100vh - 160px);
     margin-top: 60px;
+    margin-bottom: 80px;
     justify-content: flex-start;
     display: flex;
   }

--- a/css/board-mobile.css
+++ b/css/board-mobile.css
@@ -111,6 +111,7 @@
   }
 
   .tab-content-box {
+    overflow-x: auto;
     max-width: 100%;
     display: flex;
     align-items: flex-start;

--- a/css/board-mobile.css
+++ b/css/board-mobile.css
@@ -37,7 +37,6 @@
   }
 
   .searchbar {
-    width: 100vw;
     margin-top: 0;
     gap: 0;
     position: sticky;
@@ -45,8 +44,6 @@
     z-index: 10;
     background-color: #F6F7F8;
     padding-bottom: 32px;
-    padding-left: 16px;
-    padding-right: 16px;
   }
 
   .searchbar-input {

--- a/css/board.css
+++ b/css/board.css
@@ -144,10 +144,9 @@ main {
 }
 
 .tab-content-box {
+  overflow-x: auto;
   max-width: 260px;
   width: 100%;
-  height: fit-content;
-  flex: 1;
   min-width: 0;
 }
 

--- a/css/board.css
+++ b/css/board.css
@@ -144,7 +144,6 @@ main {
 }
 
 .tab-content-box {
-  overflow-x: auto;
   max-width: 260px;
   width: 100%;
   min-width: 0;


### PR DESCRIPTION
This pull request makes several adjustments to the mobile and desktop board layouts, primarily focusing on improving the layout and scrolling behavior of tab content and refining the appearance of the search bar. The changes enhance the user experience on mobile devices by improving spacing and overflow handling.

**Mobile layout improvements:**

* Added `margin-bottom: 80px;` to the `.board` container to provide extra space at the bottom of the board on mobile devices.
* Added `overflow-x: auto;` to `.tab-content-box` to allow horizontal scrolling when content overflows, ensuring better usability on smaller screens.

**Search bar appearance:**

* Removed explicit `width`, `padding-left`, and `padding-right` properties from `.searchbar` to simplify its layout and potentially improve alignment and responsiveness.

**Desktop layout adjustments:**

* Removed `height: fit-content;` and `flex: 1;` from `.tab-content-box` in the desktop board CSS to prevent unwanted stretching and ensure the box does not exceed its intended size.