### PR TITLE
Invert masked checkbox icon on check

### DIFF
--- a/css/add-task-page.css
+++ b/css/add-task-page.css
@@ -211,6 +211,10 @@
     animation: fadeOut 0.4s ease forwards;
 }
 
+.contact-label .checkbox-masked:checked::before {
+    filter: brightness(0) invert(1);
+}
+
 @keyframes slideUp {
     from { transform: translateX(-50%) translateY(100px); opacity: 0; }
     to { transform: translateX(-50%) translateY(0); opacity: 1; }


### PR DESCRIPTION
Add a CSS rule targeting .contact-label .checkbox-masked:checked::before to apply filter: brightness(0) invert(1), ensuring the masked checkbox pseudo-element is visually inverted when checked for proper contrast and visibility.