### PR TITLE
Show pointer on assignee label hover

### DIFF
--- a/css/forms.css
+++ b/css/forms.css
@@ -270,6 +270,7 @@ label.urgent:hover {
 	flex-direction: row;
 	align-items: center;
 	justify-content: space-between;
+	cursor: pointer;
 	gap: 8px;
 	border-radius: 10px;
 }


### PR DESCRIPTION
Add `cursor: pointer` to the `contact-label` rule in css/forms.css to indicate the label is interactive and improve hover affordance for users.