### PR TITLE
Add small-screen padding for contact overlays

### DIFF
--- a/css/contacts.css
+++ b/css/contacts.css
@@ -752,3 +752,14 @@ body {
         font-size: 14px;
     }
 }
+
+@media (max-width: 320px) and (max-height: 750px) {
+    .overlay-blue-part {
+        padding: 40px 20px;
+    }
+
+    .overlay-white-part {
+        padding: 0 20px 40px 20px;
+    }
+    
+}


### PR DESCRIPTION
Introduce a media query for very small viewports (max-width: 320px and max-height: 750px) to increase padding on .overlay-blue-part and .overlay-white-part, improving spacing on small phones. Also include a closing brace adjustment at the end of the file.